### PR TITLE
mark-devkit: Bump www-client/firefox-135.0-r1

### DIFF
--- a/www-client/firefox/firefox-135.0-r1.ebuild
+++ b/www-client/firefox/firefox-135.0-r1.ebuild
@@ -187,19 +187,11 @@ BDEPEND="${PYTHON_DEPS}
 	>=virtual/rust-1.59.0
 	|| (
 		(
-			sys-devel/clang:13
-			sys-devel/llvm:13
+			sys-devel/clang:16
+			sys-devel/llvm:16
 			clang? (
-				=sys-devel/lld-13*
-				pgo? ( =sys-libs/compiler-rt-sanitizers-13*[profile] )
-			)
-		)
-		(
-			sys-devel/clang:11
-			sys-devel/llvm:11
-			clang? (
-				=sys-devel/lld-11*
-				pgo? ( =sys-libs/compiler-rt-sanitizers-11*[profile] )
+				=sys-devel/lld-16*
+				pgo? ( =sys-libs/compiler-rt-sanitizers-16*[profile] )
 			)
 		)
 	)


### PR DESCRIPTION
Automatic bump of package www-client/firefox-135.0-r1 for branch mark-iii by mark-bot