### PR TITLE
mark-devkit: Bump dev-lang/spidermonkey-78.15.0-r3

### DIFF
--- a/dev-lang/spidermonkey/spidermonkey-78.15.0-r3.ebuild
+++ b/dev-lang/spidermonkey/spidermonkey-78.15.0-r3.ebuild
@@ -204,10 +204,6 @@ src_prepare() {
 		python/mozbuild/mozbuild/configure/check_debug_ranges.py \
 		|| die "sed failed to set toolchain prefix"
 
-	# fix LLVM 16 compilation
-	sed -i -e "s|'-fexperimental-new-pass-manager'||g" \
-		build/moz.configure/flags.configure || die
-
 	# use prefix shell in wrapper linker scripts, bug #789660
 	hprefixify "${S}"/../../build/cargo-{,host-}linker
 


### PR DESCRIPTION
Automatic bump of package dev-lang/spidermonkey-78.15.0-r3 for branch mark-unstable by mark-bot